### PR TITLE
Make tracing optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4.0"
 pyo3 = { version = "0.18.3", optional = true, features = ["extension-module", "abi3-py37"] }
 regex = { version = "1.8.1", default-features = false, features = ["std", "perf", "unicode-case", "unicode-perl"] }
 serde = { version = "1.0.162", features = ["derive"], optional = true }
-tracing = "0.1.37"
+tracing = { version = "0.1.37", optional = true }
 unicode-width = "0.1.10"
 
 [dev-dependencies]

--- a/src/version.rs
+++ b/src/version.rs
@@ -15,6 +15,8 @@ use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::iter;
 use std::str::FromStr;
+
+#[cfg(feature = "tracing")]
 use tracing::warn;
 
 /// A regex copied from <https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions>,
@@ -97,7 +99,10 @@ impl FromStr for Operator {
         let operator = match s {
             "==" => Self::Equal,
             "===" => {
-                warn!("Using arbitrary equality (`===`) is discouraged");
+                #[cfg(feature = "tracing")]
+                {
+                    warn!("Using arbitrary equality (`===`) is discouraged");
+                }
                 #[allow(deprecated)]
                 Self::ExactEqual
             }

--- a/src/version_specifier.rs
+++ b/src/version_specifier.rs
@@ -22,8 +22,10 @@ use std::fmt::{Debug, Display};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::str::FromStr;
-use tracing::warn;
 use unicode_width::UnicodeWidthStr;
+
+#[cfg(feature = "tracing")]
+use tracing::warn;
 
 lazy_static! {
     /// Matches a python version specifier, such as `>=1.19.a1` or `4.1.*`. Extends the PEP 440
@@ -384,7 +386,10 @@ impl VersionSpecifier {
             }
             #[allow(deprecated)]
             Operator::ExactEqual => {
-                warn!("Using arbitrary equality (`===`) is discouraged");
+                #[cfg(feature = "tracing")]
+                {
+                    warn!("Using arbitrary equality (`===`) is discouraged");
+                }
                 self.version.to_string() == version.to_string()
             }
             Operator::NotEqual => other != this,


### PR DESCRIPTION
The tracing crate is only used for two warnings in the code, but it pulls in the entire tracing system. I added some conditional compilation for that purpose.