### PR TITLE
fix: add `VersionSpecifiers::empty()`

### DIFF
--- a/src/version_specifier.rs
+++ b/src/version_specifier.rs
@@ -54,6 +54,11 @@ impl std::ops::Deref for VersionSpecifiers {
 }
 
 impl VersionSpecifiers {
+    /// Matches all versions.
+    pub fn empty() -> Self {
+        Self(Vec::new())
+    }
+
     /// Whether all specifiers match the given version
     pub fn contains(&self, version: &Version) -> bool {
         self.iter().all(|specifier| specifier.contains(version))


### PR DESCRIPTION
This PR adds `VersionSpecifiers::empty()` which is present in [the uv version of this crate](https://github.com/astral-sh/uv/blob/dfb4e5bbc8727d2a22ee0f5d16946f637b815fc3/crates/pep440-rs/src/version_specifier.rs#L56) but missing here.